### PR TITLE
fix: wire --judge flag through and stop Action from hanging

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -8,7 +8,29 @@ import (
 	"sync"
 )
 
+// NewApp builds the proxycheck CLI application. It is shared by the cmd binary
+// and the tests so both exercise the same flag wiring.
+func NewApp() *cli.App {
+	return &cli.App{
+		Name:        "proxycheck",
+		Description: "Proxy checker tool",
+		Version:     "0.0.5",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "judge", Usage: "Set judge", Value: "proxyjudge.us"},
+			&cli.IntFlag{Name: "threads", Usage: "Count of threads", Value: 10},
+		},
+		Action: Action,
+	}
+}
+
 func Action(c *cli.Context) error {
+
+	// Resolve the judge from the --judge flag before doing any work; an unknown
+	// name aborts here, so no proxy is checked.
+	judge, err := ResolveJudge(c.String("judge"))
+	if err != nil {
+		return err
+	}
 
 	// If pass args, use it or read stdin as input file with proxies
 	var feed Feed
@@ -28,7 +50,7 @@ func Action(c *cli.Context) error {
 		go func(proxyAddrs chan string) {
 			defer wg.Done()
 			for proxyAddr := range proxyAddrs {
-				if res := Check(proxyAddr, &AZEnvPhpJudge{}); res.Online {
+				if res := Check(proxyAddr, judge); res.Online {
 					fmt.Printf("%s\t%s\t%s\n", proxyAddr, strings.Join(res.Protocols, ","), res.Speed.String())
 				} else {
 					fmt.Fprintf(os.Stderr, "invalid proxy %s: %v\n", proxyAddr, res.Err)
@@ -46,6 +68,10 @@ func Action(c *cli.Context) error {
 
 		proxyAddrs <- proxyAddr
 	}
+
+	// Closing the channel lets the workers' range loops finish so wg.Wait
+	// returns once the feed is exhausted.
+	close(proxyAddrs)
 
 	wg.Wait()
 	return nil

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,18 @@
+package proxycheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApp_UnknownJudge is the regression test for the --judge flag: an unknown
+// judge name must abort with an error before any proxy is checked. A deliberately
+// unparsable address keeps the run off the network if the guard is missing.
+func TestApp_UnknownJudge(t *testing.T) {
+	err := NewApp().Run([]string{"proxycheck", "--judge", "foo", "not-an-addr"})
+	assert.Error(t, err, "unknown judge must cause a non-nil error")
+	if err != nil {
+		assert.Contains(t, err.Error(), "unknown judge: foo")
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,20 +5,10 @@ import (
 	"os"
 
 	"github.com/memclutter/proxycheck"
-	cli "github.com/urfave/cli/v2"
 )
 
 func main() {
-	if err := (&cli.App{
-		Name:        "proxycheck",
-		Description: "Proxy checker tool",
-		Version:     "0.0.5",
-		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "judge", Usage: "Set judge", Value: "proxyjudge.us"},
-			&cli.IntFlag{Name: "threads", Usage: "Count of threads", Value: 10},
-		},
-		Action: proxycheck.Action,
-	}).Run(os.Args); err != nil {
+	if err := proxycheck.NewApp().Run(os.Args); err != nil {
 		log.Fatalf("app run failed: %s", err)
 	}
 }

--- a/judges.go
+++ b/judges.go
@@ -1,6 +1,11 @@
 package proxycheck
 
-import "time"
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
 
 type AZEnvPhpJudge struct{}
 
@@ -15,4 +20,25 @@ func (j ProxyjudgeUsJudge) Timeout() time.Duration { return 1 * time.Second }
 var Judges = map[string]Judge{
 	"azenv.php":     AZEnvPhpJudge{},
 	"proxyjudge.us": ProxyjudgeUsJudge{},
+}
+
+// ResolveJudge returns the Judge registered under name. An unknown name yields
+// an error that lists the available judge names.
+func ResolveJudge(name string) (Judge, error) {
+	judge, ok := Judges[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown judge: %s (available: %s)", name, judgeNames())
+	}
+	return judge, nil
+}
+
+// judgeNames returns the registered judge names, sorted and comma-joined, so
+// error messages are deterministic.
+func judgeNames() string {
+	names := make([]string, 0, len(Judges))
+	for name := range Judges {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }

--- a/judges_test.go
+++ b/judges_test.go
@@ -1,10 +1,36 @@
 package proxycheck
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestResolveJudge(t *testing.T) {
+	t.Run("azenv.php resolves", func(t *testing.T) {
+		judge, err := ResolveJudge("azenv.php")
+		assert.NoError(t, err)
+		assert.IsType(t, AZEnvPhpJudge{}, judge)
+	})
+
+	t.Run("proxyjudge.us resolves", func(t *testing.T) {
+		judge, err := ResolveJudge("proxyjudge.us")
+		assert.NoError(t, err)
+		assert.IsType(t, ProxyjudgeUsJudge{}, judge)
+	})
+
+	t.Run("unknown name errors", func(t *testing.T) {
+		judge, err := ResolveJudge("foo")
+		assert.Nil(t, judge)
+		assert.Error(t, err)
+		if err != nil {
+			assert.Contains(t, err.Error(), "unknown judge: foo")
+			assert.Contains(t, err.Error(), "azenv.php")
+			assert.Contains(t, err.Error(), "proxyjudge.us")
+		}
+	})
+}
 
 func TestJudge_TargetURL(t *testing.T) {
 	testingTable := []struct {


### PR DESCRIPTION
## What & why

The `--judge` flag was parsed but ignored — `Action` always checked through a
hardcoded `AZEnvPhpJudge`, so the documented `proxyjudge.us` default never took
effect and `--judge azenv.php` / `--judge proxyjudge.us` behaved identically.

## Changes

- Add `ResolveJudge(name) (Judge, error)` + `judgeNames()` in `judges.go`:
  resolve the flag against the `Judges` registry; an unknown name errors and
  lists the valid names.
- `Action` resolves the judge from `--judge` **before** the worker pool, aborts
  on an unknown name (nothing is probed), and passes the resolved judge to every
  worker. The `proxyjudge.us` default now actually applies.
- **Discovered deadlock, fixed in scope:** `Action` never closed `proxyAddrs`, so
  the workers' `range` loops never ended and `wg.Wait()` blocked forever — the
  CLI hung after processing all proxies. Added `close(proxyAddrs)` after the feed
  loop. It had gone unnoticed because `Action` had no test.
- Extract `NewApp()` so the binary and tests share the same flag wiring.

## Tests (TDD)

- `TestApp_UnknownJudge` — `--judge foo` must error; was RED on the old code
  (ignored the flag, then hung 60s), now green.
- `TestResolveJudge` — valid names resolve, unknown errors with the list.
- Local: `go test ./... -race`, `go vet`, `gofmt -l`, `golangci-lint run` all
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)